### PR TITLE
✨ Use Github Actions to build packages 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
           cat manifest.xml | grep -oP 'product id="\K[^"]+' | sed 's/.*/"&"/' | paste -sd, - | sed 's/.*/[&]/' | sed 's/.*/devices=&/' >> "$GITHUB_OUTPUT"
 
   logs:
-    name: Lint job
+    name: Build package
     runs-on: ubuntu-latest
     needs: define-matrix
     strategy:
@@ -41,3 +41,10 @@ jobs:
           outputPath: ${{ matrix.device }}.prg
           device: ${{ matrix.device }}
           typeCheck: '0'
+      - name: Upload packages to release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: ${{ matrix.device }}.prg
+          asset_name: ${{ matrix.device }}.prg
+          tag: ${{ github.ref }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,24 @@
+name: Build
+
+on:
+  push:
+
+jobs:
+  logs:
+    name: Lint job
+    runs-on: ubuntu-latest
+    
+    steps:
+      - uses: actions/checkout@v1
+      - name: install sdk
+        run: curl -s https://raw.githubusercontent.com/lindell/connect-iq-sdk-manager-cli/master/install.sh | sh
+      - name: backup stats
+        run: | 
+          connect-iq-sdk-manager agreement view
+          connect-iq-sdk-manager agreement accept
+          connect-iq-sdk-manager login
+          connect-iq-sdk-manager sdk set 8.4.1
+      - name: generate key
+        run: | 
+          openssl genrsa -out developer_key.pem 4096
+          openssl pkcs8 -topk8 -inform PEM -outform DER -in developer_key.pem -out developer_key.der -nocrypt

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,13 +4,36 @@ on:
   push:
 
 jobs:
+  define-matrix:
+    runs-on: ubuntu-latest
+
+    outputs:
+      devices: ${{ steps.devices.outputs.devices }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Define devices
+        id: devices
+        run: |
+          cat manifest.xml | grep -oP 'product id="\K[^"]+' | sed 's/.*/"&"/' | paste -sd, - | sed 's/.*/[&]/' | sed 's/.*/devices=&/' >> "$GITHUB_OUTPUT"
+
   logs:
     name: Lint job
     runs-on: ubuntu-latest
+    needs: define-matrix
+    strategy:
+       matrix:
+         device: ${{ fromJSON(needs.define-matrix.outputs.devices) }}
     
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+      - name: Define device
+        env:
+          device: ${{ matrix.device }}
+        run: |
+          echo "$device"
       - name: Generate key
         run: | 
           openssl genrsa -out developer_key.pem 4096

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,11 +29,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - name: Define device
-        env:
-          device: ${{ matrix.device }}
-        run: |
-          echo "$device"
       - name: Generate key
         run: | 
           openssl genrsa -out developer_key.pem 4096
@@ -43,6 +38,6 @@ jobs:
         with:
           projectJungle: ./monkey.jungle
           developerKey: ./developer_key.der
-          outputPath: myapp.prg
-          device: fenix7s
+          outputPath: ${{ matrix.device }}.prg
+          device: ${{ matrix.device }}
           typeCheck: '0'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,16 +9,17 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-      - uses: actions/checkout@v1
-      - name: install sdk
-        run: curl -s https://raw.githubusercontent.com/lindell/connect-iq-sdk-manager-cli/master/install.sh | sh
-      - name: backup stats
-        run: | 
-          connect-iq-sdk-manager agreement view
-          connect-iq-sdk-manager agreement accept
-          connect-iq-sdk-manager login
-          connect-iq-sdk-manager sdk set 8.4.1
-      - name: generate key
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Generate key
         run: | 
           openssl genrsa -out developer_key.pem 4096
           openssl pkcs8 -topk8 -inform PEM -outform DER -in developer_key.pem -out developer_key.der -nocrypt
+      - name: Build
+        uses: blackshadev/garmin-connectiq-build-action@8.4.0
+        with:
+          projectJungle: ./monkey.jungle
+          developerKey: ./developer_key.der
+          outputPath: myapp.prg
+          device: fenix7s
+          typeCheck: '0'

--- a/manifest.xml
+++ b/manifest.xml
@@ -13,6 +13,7 @@
             <iq:product id="d2mach1"/>
             <iq:product id="descentmk2"/>
             <iq:product id="descentmk2s"/>
+            <iq:product id="enduro3"/>
             <iq:product id="epix2"/>
             <iq:product id="epix2pro42mm"/>
             <iq:product id="epix2pro47mm"/>
@@ -29,6 +30,10 @@
             <iq:product id="fenix7spro"/>
             <iq:product id="fenix7x"/>
             <iq:product id="fenix7xpro"/>
+            <iq:product id="fenix843mm"/>
+            <iq:product id="fenix847mm"/>
+            <iq:product id="fenix8solar47mm"/>
+            <iq:product id="fenix8solar51mm"/>
             <iq:product id="fr245m"/>
             <iq:product id="fr255m"/>
             <iq:product id="fr255sm"/>


### PR DESCRIPTION
This PR automates the build process for every device specified in manifest.xml and handles the deployment to GitHub Releases.

<img width="1246" height="813" alt="image" src="https://github.com/user-attachments/assets/4f904966-703a-408c-bf79-7e669c954e1e" />



While users currently have the option to sideload these packages manually, hosting them on the official Connect IQ Store would provide a much better user experience. Could you please add support for the latest devices and handle the official marketplace submission?