### PR TITLE
Add additional devices and fix artwork bug on some models

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -29,6 +29,11 @@
             <iq:product id="fenix7spro"/>
             <iq:product id="fenix7x"/>
             <iq:product id="fenix7xpro"/>
+            <iq:product id="fenix843mm"/>
+            <iq:product id="fenix847mm"/>
+            <iq:product id="fenix8pro47mm"/>
+            <iq:product id="fenix8solar47mm"/>
+            <iq:product id="fenix8solar51mm"/>
             <iq:product id="fr245m"/>
             <iq:product id="fr255m"/>
             <iq:product id="fr255sm"/>

--- a/source/Artwork.mc
+++ b/source/Artwork.mc
@@ -105,7 +105,7 @@ class IArtwork extends Artwork {
 
 	function save() {
         // do not save if id invalid
-        if (art_id == null) {
+        if (art_id() == null) {
             return false;
         }
         

--- a/source/Podcast.mc
+++ b/source/Podcast.mc
@@ -250,12 +250,12 @@ class IPodcast extends Podcast {
 		// if new artwork, load it
 		if (art_id() != null) {
 			d_artwork = new IArtwork(art_id(), Artwork.PODCAST);
-			
+
 			// reference the artwork
 			d_artwork.incRefCount();
+		} else {
+			d_artwork = null;
 		}
-
-		d_artwork = null;
 		return changed;
 	}
 

--- a/source/Song.mc
+++ b/source/Song.mc
@@ -206,12 +206,12 @@ class ISong extends Song {
 		// if new artwork, load it
 		if (art_id() != null) {
 			d_artwork = new IArtwork(art_id(), Artwork.SONG);
-			
+
 			// reference the artwork
 			d_artwork.incRefCount();
+		} else {
+			d_artwork = null;
 		}
-
-		d_artwork = null;
 		return changed;
 	}
 


### PR DESCRIPTION
Update previously supported devices list in manifest.xml (venu 3 series, venu 4 series)

[9b97ea2]  Added fenix843mm, fenix847mm, fenix8pro47mm, fenix8solar47mm,
fenix8solar51mm to manifest. Fixed artwork reference being
unconditionally nullified in Song.setArt_id and Podcast.setArt_id.
Fixed IArtwork.save() checking method reference instead of calling
art_id() getter.